### PR TITLE
Encs control thresholds

### DIFF
--- a/sway.lua
+++ b/sway.lua
@@ -304,6 +304,10 @@ end
 function enc(n, delta)
   if n == 1 then
     params:delta("output_level", delta)
+  elseif n == 2 then
+    params:delta("density_threshold", delta)
+  elseif n == 3 then
+    params:delta("clarity_threshold", delta)
   end
 end
 

--- a/sway.lua
+++ b/sway.lua
@@ -303,11 +303,11 @@ end
 
 function enc(n, delta)
   if n == 1 then
-    params:delta("output_level", delta)
+    params:delta('amp_threshold', delta)
   elseif n == 2 then
-    params:delta("density_threshold", delta)
+    params:delta('density_threshold', delta)
   elseif n == 3 then
-    params:delta("clarity_threshold", delta)
+    params:delta('clarity_threshold', delta)
   end
 end
 

--- a/sway.lua
+++ b/sway.lua
@@ -84,7 +84,7 @@ function init()
 
   t = metro.init()
   t.count = 0
-  t.time = 1
+  t.time = 0.1
   t.event = function(stage)
     redraw()
   end
@@ -206,14 +206,22 @@ function init()
 
 end
 
+function ltgt(value, threshold)
+   if value < threshold then
+      return "<"
+   else
+      return ">"
+   end
+end
+
 function draw_screen()
   if screen_number==1 then
   screen.move(0, 24)
-  screen.text("amp: ".. amp)
+  screen.text("amp: ".. amp .. " " .. ltgt(amp+0, params:get('amp_threshold')) .. " " .. params:get('amp_threshold'))
   screen.move(0, 32)
-  screen.text("density: ".. density)
+  screen.text("density: ".. density .. " " .. ltgt(density+0, params:get('density_threshold'))..  " " .. params:get('density_threshold'))
   screen.move(0, 40)
-  screen.text("clarity: ".. clarity)
+  screen.text("clarity: ".. clarity .. " " .. ltgt(clarity+0, params:get('clarity_threshold')).. " ".. params:get('clarity_threshold'))
   screen.move(0, 48)
   screen.text("X: ".. x_coord)
   screen.move(32, 48)


### PR DESCRIPTION
Hi there, thanks for powerful and surprising script.

[As discussed](https://llllllll.co/t/sway/21117/36?u=xmacex), I made a few changes while having Sway accompany myself and a crosspatched Maths for some really nice noises: I made the encoders <kbd>E1</kbd>, <kbd>E2</kbd> and <kbd>E3</kbd> set the amplitude, density and clarity thresholds. Additionally I made the thresholds visible on the analysis page next to their current values with a little `<` or `>` indicator, and increased the screen redraw rate from 1Hz to 10Hz.

![sway-encodering.gif](https://github.com/user-attachments/assets/b80177bf-f889-4fba-8bb2-b804bb886d10)

You mentioned these could be interesting changes to consider to be included. Please let me know if there is anything which would better be done in some other way, or changes which could be included/excluded to keep with the original and/or current vision of Sway.